### PR TITLE
Prefer const over let

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ afterEach(done => rimraf(tmp, done))
 test('successfully write file', (assert) => {
   assert.plan(2)
 
-  let target = path.join(tmp, 'foo')
+  const target = path.join(tmp, 'foo')
 
   mkdirp(tmp)
     .then(() => write(target, 'bar'))
@@ -33,7 +33,7 @@ test("throw a type error when the path isn't a string", assert => {
 test('throw an error when the encoding is not supported', assert => {
   assert.plan(1)
 
-  let target = path.join(tmp, 'fake', 'path')
+  const target = path.join(tmp, 'fake', 'path')
 
   write(target, 'foo')
     .catch((err) => assert.equal(err.code, 'ENOENT'))


### PR DESCRIPTION
In order to comply with this new standard rule ☺️ 

https://github.com/standard/eslint-config-standard/pull/133

## Description
Changed from `let` to `const` where the binding never changed

## Motivation and Context
It complies with the next version of Standard

## How Has This Been Tested?
Ran a local version of `standard`

## Screenshots (if appropriate):

## Types of changes
- [ ] Bugfix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Tests _(fix, improvement, new tests)_
- [x] Code style update _(formatting, local variables)_
- [x] Refactoring _(no functional changes, no api changes)_
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other... Please describe: 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.